### PR TITLE
Bump vue-tsc to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "typescript": "^5.3.3",
         "vue-loader": "^17.2.2",
         "vue-template-compiler": "^2.7.14",
-        "vue-tsc": "^1.8.27",
+        "vue-tsc": "^2.0.6",
         "webpack": "^5.77.0",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.7.3",


### PR DESCRIPTION
Bumping this because support for vue 3.4 features like v-bind shortcut syntax was only recently added, see https://github.com/vuejs/language-tools/issues/3830

Was necessitating workaround for problems like https://github.com/vuejs/language-tools/issues/3901