### PR TITLE
Add DefinitelyTyped types for `js-cookie`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "@babel/plugin-transform-class-properties": "^7.24.1",
         "@babel/plugin-transform-runtime": "^7.24.3",
         "@babel/preset-env": "^7.24.2",
+        "@types/js-cookie": "^3.0.6",
         "@typescript-eslint/parser": "^8.0.0-alpha.11",
         "@vitejs/plugin-vue": "^5.0.4",
         "@vitest/coverage-v8": "^1.5.0",


### PR DESCRIPTION
After https://github.com/archesproject/arches/pull/10926, this allows getting type-checking for usage of `js-cookie`.