### PR TITLE
Bump `vue-tsc` to 2.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "vitest": "^1.5.0",
         "vue-loader": "^17.4.2",
         "vue-template-compiler": "^2.7.16",
-        "vue-tsc": "^2.0.13",
+        "vue-tsc": "^2.1.6",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4",


### PR DESCRIPTION
Raise the floor on vue-tsc to avoid the error in 2.0.29 described [here](https://github.com/vuejs/language-tools/issues/4738).

Then let's merge into dev/8.0