### PR TITLE
Remove `vue-template-compiler`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
         "typescript-eslint": "^8.0.0-alpha.11",
         "vitest": "^1.5.0",
         "vue-loader": "^17.4.2",
-        "vue-template-compiler": "^2.7.16",
         "vue-tsc": "^2.1.6",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",


### PR DESCRIPTION
vue-template-compiler is for loading vue 2.x templates, which we don't support anyway. Tested rebuilding lingo with this branch: still builds.

Resolves a dependabot [alert](https://github.com/archesproject/arches/security/dependabot/96) on an unpatched security vulnerability in the package.

Will open a sidecar PR to arches to add release note and remake package-lock.