### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "postcss-loader": "^8.1.1",
         "prettier": "3.3.0",
         "raw-loader": "^4.0.2",
-        "sass": "^1.75.0",
+        "sass": "1.78.0",
         "sass-loader": "^14.2.0",
         "style-loader": "^4.0.0",
         "stylelint": "^16.3.1",


### PR DESCRIPTION
From sass 1.79.0+, there are deprecation warnings about certain Arches patterns that will be deprecated in sass 2.0 .  For all intents and purposes these warning are not silence-able.

The correct solution would be to change the deprecated patterns, but that change would very involved and assuredly breaking.

exact-pinning to sass 1.78.0 silences these warnings. Further, as we continue development in Vue ( and continue to leverage PrimeVue theming ) these deprecated sass patterns will eventually be taken out of the codebase.